### PR TITLE
feat(1.0.7): flat-topology launch args for filebeat + logstash

### DIFF
--- a/charts/filebeat/Chart.yaml
+++ b/charts/filebeat/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
   - logging
   - elastic
   - filebeat
-version: 1.0.6
-appVersion: 1.0.6
+version: 1.0.7
+appVersion: 1.0.7
 icon: https://raw.githubusercontent.com/log-10x/elastic-helm-charts/main/icon.png
 home: https://github.com/log-10x/elastic-helm-charts
 sources:
@@ -21,4 +21,8 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgraded 10x engine to 1.0.6"
+      description: "Upgraded 10x engine to 1.0.7"
+    - kind: changed
+      description: "Launch args now target the flat apps/ topology (apps/reporter, apps/regulator) baked into the 1.0.7 image — replaces the 1.0.6 nested apps/edge/* paths"
+    - kind: changed
+      description: "kind=optimize now launches @apps/regulator with regulatorOptimize=true env (replaces apps/edge/optimizer, which is absent in 1.0.7 — optimize is a regulator flag now)"

--- a/charts/filebeat/templates/daemonset.yaml
+++ b/charts/filebeat/templates/daemonset.yaml
@@ -250,11 +250,20 @@ spec:
         {{- end }}
         - name: TENX_RUN_ARGS
         {{- if eq $.Values.tenx.kind "optimize" }}
-          value: "@run/input/forwarder/filebeat/optimize/config.yaml @apps/edge/optimizer"
+          # 1.0.7: optimize is a regulator flag, not a separate app.
+          # @apps/edge/optimizer no longer exists in the pipeline-10x:1.0.7
+          # image — the flat topology has apps/regulator only. The
+          # regulator pipeline reads regulatorOptimize (env var, below)
+          # and flips encodeObjects on when true.
+          value: "@run/input/forwarder/filebeat/regulate/config.yaml @apps/regulator"
         {{- else if eq $.Values.tenx.kind "regulate" }}
-          value: "@run/input/forwarder/filebeat/regulate/config.yaml @apps/edge/regulator"
+          value: "@run/input/forwarder/filebeat/regulate/config.yaml @apps/regulator"
         {{- else if eq $.Values.tenx.kind "report" }}
-          value: "@run/input/forwarder/filebeat/report/config.yaml @apps/edge/reporter"
+          value: "@run/input/forwarder/filebeat/report/config.yaml @apps/reporter"
+        {{- end }}
+        {{- if eq $.Values.tenx.kind "optimize" }}
+        - name: regulatorOptimize
+          value: "true"
         {{- end }}
         {{- end }}
 {{- if .Values.extraEnvs | default .Values.daemonset.extraEnvs }}

--- a/charts/logstash/Chart.yaml
+++ b/charts/logstash/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - logging
   - elastic
   - logstash
-version: 1.0.6
+version: 1.0.7
 appVersion: 8.5.1
 icon: https://raw.githubusercontent.com/log-10x/elastic-helm-charts/main/icon.png
 home: https://github.com/log-10x/elastic-helm-charts
@@ -21,4 +21,10 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgraded 10x sidecar engine to 1.0.6"
+      description: "Upgraded 10x sidecar engine to 1.0.7 (pipeline-10x:1.0.7)"
+    - kind: changed
+      description: "Launch args now target the flat apps/ topology (apps/reporter, apps/regulator) baked into the 1.0.7 image — replaces the 1.0.6 nested apps/edge/* paths"
+    - kind: changed
+      description: "kind=optimize now launches @apps/regulator with regulatorOptimize=true env (replaces apps/edge/optimizer, which is absent in 1.0.7 — optimize is a regulator flag now)"
+    - kind: changed
+      description: "Default tenx sidecar image tag bumped to 1.0.7"

--- a/charts/logstash/templates/statefulset.yaml
+++ b/charts/logstash/templates/statefulset.yaml
@@ -296,8 +296,17 @@ spec:
         imagePullPolicy: {{ .Values.tenx.image.pullPolicy }}
         args:
           - "run"
-          - "@run/input/forwarder/logstash/{{ .Values.tenx.kind }}"
-          - "@apps/edge/{{ if eq .Values.tenx.kind "report" }}reporter{{ else if eq .Values.tenx.kind "regulate" }}regulator{{ else }}optimizer{{ end }}"
+          {{- if eq .Values.tenx.kind "report" }}
+          - "@run/input/forwarder/logstash/report"
+          - "@apps/reporter"
+          {{- else }}
+          # kind=regulate or kind=optimize: both run the regulator
+          # pipeline against the flat apps/regulator module (1.0.7).
+          # @apps/edge/* is gone in 1.0.7 — optimize is now a regulator
+          # flag (regulatorOptimize env, below), not a separate app.
+          - "@run/input/forwarder/logstash/regulate"
+          - "@apps/regulator"
+          {{- end }}
         env:
           - name: TENX_API_KEY
           {{- if .Values.tenx.apiKey }}
@@ -307,6 +316,10 @@ spec:
                 key: api-key
           {{- else }}
             value: ""
+          {{- end }}
+          {{- if eq .Values.tenx.kind "optimize" }}
+          - name: regulatorOptimize
+            value: "true"
           {{- end }}
           {{- if .Values.tenx.runtimeName }}
           - name: TENX_RUNTIME_NAME


### PR DESCRIPTION
## Summary

Bumps `filebeat` and `logstash` charts to 1.0.7, matching the fluent-bit/fluentd migration merged in fluent-helm-charts PR #7.

The `pipeline-10x:1.0.7` image (used as the tenx sidecar for logstash) and `filebeat-10x:1.0.7-jit` ship modules with flat `apps/{reporter,regulator,compiler,streamer,dev,shared}` layout. The nested `apps/edge/*` tree is gone — in particular `apps/edge/optimizer` no longer exists (the 1.0.7 engine treats optimize as a regulator flag via `regulatorOptimize` env var, not as a separate app).

## Changes

**filebeat chart:**
- `version` + `appVersion` → 1.0.7
- `TENX_RUN_ARGS` launch strings: `@apps/edge/<kind>` → `@apps/<kind>`
- `kind=optimize` → `@apps/regulator` + `regulatorOptimize=true` env var

**logstash chart:**
- `version` → 1.0.7 (`appVersion` stays `8.5.1` — tracks upstream logstash)
- Sidecar launch args: `@apps/<kind>` remap + `regulatorOptimize` env
- `kind=report` → `@apps/reporter`; `regulate`/`optimize` → `@apps/regulator`

User-facing `tenx.kind` enum (`report`|`regulate`|`optimize`) is preserved — only the internal launch strings change.

## Why

Eliminates both charts' dependency on the config repo's `apps/edge/` overlay, which was a transitional band-aid for the pre-1.0.7 nested module layout.

## Test plan

- [x] `helm template` renders correctly for all three kinds on both charts (inspected launch args + env vars)
- [ ] E2E install on demo cluster after merge (tracked in log10x-mcp dogfood)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
