### PR TITLE
refactor(charts): rename regulator → reducer (filebeat + logstash 1.0.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ tenx:
 
 - [Log10x Documentation](https://doc.log10x.com)
 - [Edge Reporter Deployment](https://doc.log10x.com/apps/edge/reporter/deploy/)
-- [Edge Regulator Deployment](https://doc.log10x.com/apps/edge/regulator/deploy/)
+- [Edge Reducer Deployment](https://doc.log10x.com/apps/reducer/deploy/)
 - [Edge Optimizer Deployment](https://doc.log10x.com/apps/edge/optimizer/deploy/)
 
 ## License

--- a/charts/filebeat/Chart.yaml
+++ b/charts/filebeat/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - logging
   - elastic
   - filebeat
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.0.7
 icon: https://raw.githubusercontent.com/log-10x/elastic-helm-charts/main/icon.png
 home: https://github.com/log-10x/elastic-helm-charts
@@ -23,6 +23,6 @@ annotations:
     - kind: changed
       description: "Upgraded 10x engine to 1.0.7"
     - kind: changed
-      description: "Launch args now target the flat apps/ topology (apps/reporter, apps/regulator) baked into the 1.0.7 image — replaces the 1.0.6 nested apps/edge/* paths"
+      description: "Launch args now target the flat apps/ topology (apps/reporter, apps/reducer) baked into the 1.0.7 image — replaces the 1.0.6 nested apps/edge/* paths"
     - kind: changed
-      description: "kind=optimize now launches @apps/regulator with regulatorOptimize=true env (replaces apps/edge/optimizer, which is absent in 1.0.7 — optimize is a regulator flag now)"
+      description: "kind=optimize now launches @apps/reducer with reducerOptimize=true env (replaces apps/edge/optimizer, which is absent in 1.0.7 — optimize is a reducer flag now)"

--- a/charts/filebeat/README.md
+++ b/charts/filebeat/README.md
@@ -151,14 +151,14 @@ daemonset:
 
 See the [samples](../../samples/) directory for example configurations:
 - `filebeat-report.yaml` - Reporter mode for analytics
-- `filebeat-regulate.yaml` - Regulator mode for filtering
+- `filebeat-regulate.yaml` - Reducer mode for filtering
 - `filebeat-optimize.yaml` - Optimizer mode for full optimization
 
 ## Documentation
 
 - [Log10x Documentation](https://doc.log10x.com)
 - [Edge Reporter Deployment](https://doc.log10x.com/apps/edge/reporter/deploy/)
-- [Edge Regulator Deployment](https://doc.log10x.com/apps/edge/regulator/deploy/)
+- [Edge Reducer Deployment](https://doc.log10x.com/apps/reducer/deploy/)
 - [Edge Optimizer Deployment](https://doc.log10x.com/apps/edge/optimizer/deploy/)
 
 ## License

--- a/charts/filebeat/templates/daemonset.yaml
+++ b/charts/filebeat/templates/daemonset.yaml
@@ -250,19 +250,19 @@ spec:
         {{- end }}
         - name: TENX_RUN_ARGS
         {{- if eq $.Values.tenx.kind "optimize" }}
-          # 1.0.7: optimize is a regulator flag, not a separate app.
+          # 1.0.7: optimize is a reducer flag, not a separate app.
           # @apps/edge/optimizer no longer exists in the pipeline-10x:1.0.7
-          # image — the flat topology has apps/regulator only. The
-          # regulator pipeline reads regulatorOptimize (env var, below)
+          # image — the flat topology has apps/reducer only. The
+          # reducer pipeline reads reducerOptimize (env var, below)
           # and flips encodeObjects on when true.
-          value: "@run/input/forwarder/filebeat/regulate/config.yaml @apps/regulator"
+          value: "@run/input/forwarder/filebeat/regulate/config.yaml @apps/reducer"
         {{- else if eq $.Values.tenx.kind "regulate" }}
-          value: "@run/input/forwarder/filebeat/regulate/config.yaml @apps/regulator"
+          value: "@run/input/forwarder/filebeat/regulate/config.yaml @apps/reducer"
         {{- else if eq $.Values.tenx.kind "report" }}
           value: "@run/input/forwarder/filebeat/report/config.yaml @apps/reporter"
         {{- end }}
         {{- if eq $.Values.tenx.kind "optimize" }}
-        - name: regulatorOptimize
+        - name: reducerOptimize
           value: "true"
         {{- end }}
         {{- end }}

--- a/charts/filebeat/values.yaml
+++ b/charts/filebeat/values.yaml
@@ -174,7 +174,7 @@ daemonset:
   # components that are part of the 10x pipeline deployment:
   #
   # 1. Monitor of the 10x internal log, and reporting it to elasticsearch
-  # 2. Setting up the JS processor (all apps) and 10x read-back ('regulator'/'optimizer')
+  # 2. Setting up the JS processor (all apps) and 10x read-back ('reducer'/'optimizer')
   #    for the integration between the 10x pipeline and filebeat
   # 3. Reporting 10x template objects to elasticsearch ('optimizer' only)
   #

--- a/charts/logstash/Chart.yaml
+++ b/charts/logstash/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - logging
   - elastic
   - logstash
-version: 1.0.7
+version: 1.0.8
 appVersion: 8.5.1
 icon: https://raw.githubusercontent.com/log-10x/elastic-helm-charts/main/icon.png
 home: https://github.com/log-10x/elastic-helm-charts
@@ -23,8 +23,8 @@ annotations:
     - kind: changed
       description: "Upgraded 10x sidecar engine to 1.0.7 (pipeline-10x:1.0.7)"
     - kind: changed
-      description: "Launch args now target the flat apps/ topology (apps/reporter, apps/regulator) baked into the 1.0.7 image — replaces the 1.0.6 nested apps/edge/* paths"
+      description: "Launch args now target the flat apps/ topology (apps/reporter, apps/reducer) baked into the 1.0.7 image — replaces the 1.0.6 nested apps/edge/* paths"
     - kind: changed
-      description: "kind=optimize now launches @apps/regulator with regulatorOptimize=true env (replaces apps/edge/optimizer, which is absent in 1.0.7 — optimize is a regulator flag now)"
+      description: "kind=optimize now launches @apps/reducer with reducerOptimize=true env (replaces apps/edge/optimizer, which is absent in 1.0.7 — optimize is a reducer flag now)"
     - kind: changed
       description: "Default tenx sidecar image tag bumped to 1.0.7"

--- a/charts/logstash/README.md
+++ b/charts/logstash/README.md
@@ -133,7 +133,7 @@ For the complete list of configuration options, see [values.yaml](./values.yaml)
 
 - [Log10x Documentation](https://doc.log10x.com)
 - [Edge Reporter Deployment](https://doc.log10x.com/apps/edge/reporter/deploy/)
-- [Edge Regulator Deployment](https://doc.log10x.com/apps/edge/regulator/deploy/)
+- [Edge Reducer Deployment](https://doc.log10x.com/apps/reducer/deploy/)
 - [Edge Optimizer Deployment](https://doc.log10x.com/apps/edge/optimizer/deploy/)
 
 ## License

--- a/charts/logstash/templates/statefulset.yaml
+++ b/charts/logstash/templates/statefulset.yaml
@@ -300,12 +300,12 @@ spec:
           - "@run/input/forwarder/logstash/report"
           - "@apps/reporter"
           {{- else }}
-          # kind=regulate or kind=optimize: both run the regulator
-          # pipeline against the flat apps/regulator module (1.0.7).
-          # @apps/edge/* is gone in 1.0.7 — optimize is now a regulator
-          # flag (regulatorOptimize env, below), not a separate app.
+          # kind=regulate or kind=optimize: both run the reducer
+          # pipeline against the flat apps/reducer module (1.0.7).
+          # @apps/edge/* is gone in 1.0.7 — optimize is now a reducer
+          # flag (reducerOptimize env, below), not a separate app.
           - "@run/input/forwarder/logstash/regulate"
-          - "@apps/regulator"
+          - "@apps/reducer"
           {{- end }}
         env:
           - name: TENX_API_KEY
@@ -318,7 +318,7 @@ spec:
             value: ""
           {{- end }}
           {{- if eq .Values.tenx.kind "optimize" }}
-          - name: regulatorOptimize
+          - name: reducerOptimize
             value: "true"
           {{- end }}
           {{- if .Values.tenx.runtimeName }}

--- a/samples/filebeat-regulate.yaml
+++ b/samples/filebeat-regulate.yaml
@@ -1,17 +1,17 @@
-# Sample values.yaml for deploying an 10x edge regulator with filebeat
+# Sample values.yaml for deploying an 10x edge reducer with filebeat
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the filebeat.yml config
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/edge/regulator/deploy/#filebeat
+# https://doc.log10x.com/apps/reducer/deploy/#filebeat
 #
 tenx:
   apiKey: "<YOUR-10X-API-KEY-HERE>"
 
   kind: "regulate"
 
-  runtimeName: "my-filebeat-regulator"
+  runtimeName: "my-filebeat-reducer"
 
 daemonset:
   filebeatConfig:


### PR DESCRIPTION
## Summary
- `@apps/regulator` → `@apps/reducer` in filebeat daemonset + logstash statefulset
- `regulatorOptimize` → `reducerOptimize` env var
- Doc URLs flattened: `/apps/edge/reducer/` → `/apps/reducer/`
- `tenx.kind` values (regulate/optimize) preserved — action verbs, not app names
- Chart versions: filebeat 1.0.7 → 1.0.8, logstash 1.0.7 → 1.0.8

Companion to log-10x/modules#21, log-10x/config#20, log-10x/mksite#26, log-10x/opentelemetry-helm-charts#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)