### PR TITLE
chore: bump filebeat to engine 1.0.17 + logstash sidecar default

### DIFF
--- a/charts/filebeat/Chart.yaml
+++ b/charts/filebeat/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
   - logging
   - elastic
   - filebeat
-version: 1.0.10
-appVersion: 1.0.16
+version: 1.0.11
+appVersion: 1.0.17
 icon: https://raw.githubusercontent.com/log-10x/elastic-helm-charts/main/icon.png
 home: https://github.com/log-10x/elastic-helm-charts
 sources:

--- a/charts/logstash/Chart.yaml
+++ b/charts/logstash/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - logging
   - elastic
   - logstash
-version: 1.0.10
+version: 1.0.11
 appVersion: 8.5.1
 icon: https://raw.githubusercontent.com/log-10x/elastic-helm-charts/main/icon.png
 home: https://github.com/log-10x/elastic-helm-charts

--- a/charts/logstash/templates/statefulset.yaml
+++ b/charts/logstash/templates/statefulset.yaml
@@ -292,7 +292,7 @@ spec:
       {{- end }}
       {{- if .Values.tenx.enabled }}
       - name: tenx
-        image: "{{ .Values.tenx.image.repository }}:{{ .Values.tenx.image.tag | default .Chart.Version }}"
+        image: "{{ .Values.tenx.image.repository }}:{{ .Values.tenx.image.tag | default "1.0.17" }}"
         imagePullPolicy: {{ .Values.tenx.image.pullPolicy }}
         args:
           - "run"


### PR DESCRIPTION
filebeat appVersion 1.0.16 to 1.0.17 (engine with modules#34 fix). logstash sidecar tag default hardcoded to 1.0.17.