### PR TITLE
docs(readme): tag website links with GitHub-source UTMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This repository contains [Helm](https://helm.sh/) charts for Elastic Stack components with integrated [Log10x](https://log10x.com) sidecar support.
+This repository contains [Helm](https://helm.sh/) charts for Elastic Stack components with integrated [Log10x](https://www.log10x.com/?utm_source=github&utm_medium=readme&utm_campaign=elastic-helm-charts&utm_content=hero) sidecar support.
 
 **Forked from:** [elastic/helm-charts](https://github.com/elastic/helm-charts)
 
@@ -88,7 +88,7 @@ itself is open source, **using Log10x requires a commercial license**.
 - A valid Log10x API key is required to run the deployed software
 
 **Get Started:**
-- [Log10x Pricing](https://log10x.com/pricing)
+- [Log10x Pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=elastic-helm-charts&utm_content=footer)
 - [Documentation](https://doc.log10x.com)
 - [Contact Sales](mailto:sales@log10x.com)
 

--- a/charts/filebeat/README.md
+++ b/charts/filebeat/README.md
@@ -163,4 +163,4 @@ See the [samples](../../samples/) directory for example configurations:
 
 This chart is licensed under the Apache License 2.0.
 
-**Note:** The Log10x engine requires a commercial license. See [Log10x Pricing](https://log10x.com/pricing) for details.
+**Note:** The Log10x engine requires a commercial license. See [Log10x Pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=elastic-helm-charts&utm_content=inline) for details.

--- a/charts/logstash/README.md
+++ b/charts/logstash/README.md
@@ -138,4 +138,4 @@ For the complete list of configuration options, see [values.yaml](./values.yaml)
 
 This chart is licensed under the Apache License 2.0.
 
-**Note:** The Log10x engine requires a commercial license. See [Log10x Pricing](https://log10x.com/pricing) for details.
+**Note:** The Log10x engine requires a commercial license. See [Log10x Pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=elastic-helm-charts&utm_content=inline) for details.


### PR DESCRIPTION
Tags this repo's **www.log10x.com** README links with GitHub-source UTMs so traffic from this repo's README is attributable per-repo in GA4/PostHog.

**Scheme:** `utm_source=github&utm_medium=readme&utm_campaign=elastic-helm-charts&utm_content=<location>`

Files:
- `README.md`
- `charts/filebeat/README.md`
- `charts/logstash/README.md`

Display text unchanged; `doc.`/`console.`/`mailto:` left untagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)